### PR TITLE
Fix history save display and close PDF

### DIFF
--- a/chat_aluno.py
+++ b/chat_aluno.py
@@ -34,7 +34,8 @@ with gr.Blocks() as demo:
         botao = gr.Button("Perguntar")
     resposta = gr.Textbox(label="Resposta da IA", lines=6)
     trechos_usados = gr.Textbox(label="Trechos do material usados", lines=6)
+    status = gr.Textbox(label="Status", value="", interactive=False)
     botao.click(fn=interagir, inputs=pergunta, outputs=[resposta, trechos_usados])
-    gr.Button("Salvar histórico").click(fn=salvar_historico, outputs=gr.Textbox(value=""))
+    gr.Button("Salvar histórico").click(fn=salvar_historico, outputs=status)
 
 demo.launch()

--- a/processar_aulas.py
+++ b/processar_aulas.py
@@ -15,9 +15,9 @@ model = SentenceTransformer("all-MiniLM-L6-v2")
 
 def extrair_texto_pdf(caminho_pdf):
     texto = ""
-    doc = fitz.open(caminho_pdf)
-    for pagina in doc:
-        texto += pagina.get_text()
+    with fitz.open(caminho_pdf) as doc:
+        for pagina in doc:
+            texto += pagina.get_text()
     return texto
 
 def dividir_em_chunks(texto, tamanho=50):


### PR DESCRIPTION
## Summary
- close PDF files in a context manager in `processar_aulas.py`
- show save message in `chat_aluno.py` using a dedicated textbox

## Testing
- `python3 -m py_compile base_consulta.py gerar_resposta.py processar_aulas.py chat_aluno.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d9b885b88327bec7b236556c9098