### PR TITLE
Fix dependency typo in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ sentence-transformers
 PyMuPDF
 requests
 numpy
-hf_xet
+huggingface-hub
 nltk


### PR DESCRIPTION
## Summary
- fix package name `hf_xet` → `huggingface-hub`
- ensure file ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843585c7ce083278f1702f9075163fa