### PR TITLE
Add reset base button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ python chat_aluno.py
 
 A página do Gradio permite enviar uma pergunta. O script usa `gerar_resposta.py` para chamar um servidor compatível com a API OpenAI (ex.: LM Studio) que deve estar rodando em `http://localhost:1234`.
 
+Também há um botão "Resetar base" para apagar os arquivos processados e recomeçar do zero.
+
 ## Scripts auxiliares
 
 - **base_consulta.py** – realiza a busca vetorial nos chunks usando FAISS.

--- a/chat_aluno.py
+++ b/chat_aluno.py
@@ -5,7 +5,7 @@ import shutil
 import gradio as gr
 from gerar_resposta import gerar_resposta
 from base_consulta import consultar_vetorial
-from processar_aulas import processar_todos
+from processar_aulas import processar_todos, resetar_base
 
 PASTA_DESTINO = "dados/aulas_originais"
 
@@ -63,6 +63,11 @@ def salvar_arquivos(pdfs):
     return f"✅ {len(nomes_salvos)} arquivo(s) salvo(s) em `{PASTA_DESTINO}`:\n\n" + "\n".join(nomes_salvos)
 
 
+def resetar_dados():
+    resetar_base()
+    return "✅ Base de dados resetada!"
+
+
 
 
 with gr.Blocks() as demo:
@@ -75,6 +80,7 @@ with gr.Blocks() as demo:
     status = gr.Textbox(label="Status", value="", interactive=False)
     botao.click(fn=interagir, inputs=pergunta, outputs=[resposta, trechos_usados])
     gr.Button("Salvar histórico").click(fn=salvar_historico, outputs=status)
+    gr.Button("Resetar base").click(fn=resetar_dados, outputs=status)
 
     ## função upar arquivos
     gr.Markdown("## 📘 Envie os PDFs para Análise")


### PR DESCRIPTION
## Summary
- add `resetar_dados` helper in `chat_aluno.py`
- show new 'Resetar base' button in the Gradio UI
- mention the new button in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68435df6e23c8327b53b9db3dc0f4ff6