### PR TITLE
Add per-personality prompt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,7 @@ Também há um botão "Resetar base" para apagar os arquivos processados e recom
 
 - **base_consulta.py** – realiza a busca vetorial nos chunks usando FAISS.
 - **gerar_resposta.py** – monta o prompt a partir dos trechos encontrados e envia para o servidor de linguagem.
+- **dados/personalidades/** – contém um arquivo `.json` para cada personalidade de prompt.
+
+Para criar novas personalidades, adicione um JSON em `dados/personalidades` com a chave `"template"` contendo o texto do prompt. O nome do arquivo (sem extensão) é o identificador usado por `gerar_resposta.py`.
 

--- a/dados/personalidades/animada.json
+++ b/dados/personalidades/animada.json
@@ -1,0 +1,3 @@
+{
+  "template": "Você é uma colega virtual super animada que adora Química e usa emojis para incentivar o aluno.\n\nMaterial da aula:\n\n{contexto}\n\nResponda de forma breve e divertida à pergunta:\n\n\"{pergunta}\"\n"
+}

--- a/dados/personalidades/colega_quimica.json
+++ b/dados/personalidades/colega_quimica.json
@@ -1,0 +1,3 @@
+{
+  "template": "Você é uma colega virtual que ajuda o aluno a aprender Química.\nSeu papel é dar sugestões, instigar, e guiar o raciocínio.\n\nAqui está o material da aula, enviado pelo professor:\n\n{contexto}\n\nCom base nesse conteúdo, NUNCA diga algo que contraria a ideia do professor, ajude o aluno com a seguinte pergunta:\n\n\"{pergunta}\"\n\nLembre-se:\n- Incentive o aluno a pensar.\n- Use exemplos simples.\n- Foque no que foi dito pelo professor, e se baseie em dar exemplos que o professor deu.\n"
+}

--- a/gerar_resposta.py
+++ b/gerar_resposta.py
@@ -1,32 +1,38 @@
 # ==== 3. gerar_resposta.py ====
 
+import json
+import os
 import requests
 from base_consulta import consultar_vetorial
 
-def montar_prompt(trechos, pergunta):
-    contexto = "\n\n".join([f"- {t}" for t in trechos])
-    return f"""
-Você é uma colega virtual que ajuda o aluno a aprender Química. 
-Seu papel é dar sugestões, instigar, e guiar o raciocínio.
+# Pasta onde ficam os arquivos de personalidade (um JSON por modelo)
+PASTA_PERSONALIDADES = os.path.join("dados", "personalidades")
 
-Aqui está o material da aula, enviado pelo professor:
+def carregar_template(personalidade: str) -> str:
+    """Retorna o template de prompt da personalidade solicitada."""
+    caminho = os.path.join(PASTA_PERSONALIDADES, f"{personalidade}.json")
+    if not os.path.exists(caminho):
+        raise FileNotFoundError(f"Arquivo de personalidade '{personalidade}' não encontrado em {PASTA_PERSONALIDADES}.")
+    with open(caminho, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        template = data.get("template")
+    else:
+        template = data
+    if not template:
+        raise ValueError(f"Template vazio em {caminho}.")
+    return template
 
-{contexto}
-
-Com base nesse conteúdo, NUNCA diga algo que contraria a ideia do professor, ajude o aluno com a seguinte pergunta:
-
-"{pergunta}"
-
-Lembre-se:
-- Incentive o aluno a pensar.
-- Use exemplos simples.
-- Foque no que foi dito pelo professor, e se baseie em dar exemplos que o professor deu.
-""".strip()
+def montar_prompt(trechos, pergunta, personalidade: str = "colega_quimica") -> str:
+    """Monta o prompt a partir do template e dos trechos fornecidos."""
+    contexto = "\n\n".join(f"- {t}" for t in trechos)
+    template = carregar_template(personalidade)
+    return template.format(contexto=contexto, pergunta=pergunta).strip()
 
 
-def gerar_resposta(pergunta, modelo="lmstudio", k=3):
+def gerar_resposta(pergunta, modelo="lmstudio", k=3, personalidade: str = "colega_quimica"):
     consulta = consultar_vetorial(pergunta, k=k)
-    prompt = montar_prompt(consulta["trechos"], pergunta)
+    prompt = montar_prompt(consulta["trechos"], pergunta, personalidade)
 
     resposta = requests.post(
         "http://localhost:1234/v1/chat/completions",


### PR DESCRIPTION
## Summary
- move prompt templates to `dados/personalidades/`
- load chosen personality file in `gerar_resposta`
- document folder of personalities in README

## Testing
- `python -m py_compile gerar_resposta.py`
- `python -m py_compile chat_aluno.py`


------
https://chatgpt.com/codex/tasks/task_e_6843635c2858832797b2cef2de06f871