### PR TITLE
Allow question submission via Enter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A página do Gradio permite enviar uma pergunta. O script usa `gerar_resposta.py
 
 Há um menu suspenso **Personalidade** para escolher qual arquivo de template usar na resposta.
 
+Também é possível pressionar **Enter** no campo de pergunta para enviar a mensagem sem clicar no botão.
+
 Também há um botão "Resetar base" para apagar os arquivos processados e recomeçar do zero.
 
 ## Scripts auxiliares

--- a/chat_aluno.py
+++ b/chat_aluno.py
@@ -91,6 +91,7 @@ with gr.Blocks() as demo:
     trechos_usados = gr.Textbox(label="Trechos do material usados", lines=6)
     status = gr.Textbox(label="Status", value="", interactive=False)
     botao.click(fn=interagir, inputs=[pergunta, personalidade], outputs=[resposta, trechos_usados])
+    pergunta.submit(fn=interagir, inputs=[pergunta, personalidade], outputs=[resposta, trechos_usados])
     gr.Button("Salvar histórico").click(fn=salvar_historico, outputs=status)
     gr.Button("Resetar base").click(fn=resetar_dados, outputs=status)
 


### PR DESCRIPTION
## Summary
- enable automatic submission when pressing Enter in the question textbox
- document the new shortcut in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684375902e688327a173d04c15327a10