### PR TITLE
Improve trechos visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Há um menu suspenso **Personalidade** para escolher qual arquivo de template us
 
 Também há um botão "Resetar base" para apagar os arquivos processados e recomeçar do zero.
 
+Por padrão, os trechos do material usados na resposta ficam ocultos. O
+controle **Trechos** permite exibi‑los ou escondê‑los a qualquer momento, e a
+escolha é respeitada sempre que uma nova resposta é gerada.
+
 ## Scripts auxiliares
 
 - **base_consulta.py** – realiza a busca vetorial nos chunks usando FAISS.

--- a/chat_aluno.py
+++ b/chat_aluno.py
@@ -23,7 +23,7 @@ def listar_personalidades():
 PERSONALIDADES = listar_personalidades()
 PERSONALIDADE_PADRAO = "colega_quimica" if "colega_quimica" in PERSONALIDADES else (PERSONALIDADES[0] if PERSONALIDADES else "")
 
-def interagir(pergunta, personalidade):
+def interagir(pergunta, personalidade, opcao_trechos):
     resposta = gerar_resposta(pergunta, personalidade=personalidade)
     consulta = consultar_vetorial(pergunta)
     trechos = consulta["trechos"]
@@ -41,7 +41,9 @@ def interagir(pergunta, personalidade):
         f"\u2022 {t[:100]}... 📁 Origem: `{o[:50]}`"
         for t, o in zip(trechos, origens)
     ])
-    return resposta, trecho_formatado
+    return resposta, gr.update(
+        value=trecho_formatado, visible=opcao_trechos == "Mostrar"
+    )
 
 
 def salvar_historico():
@@ -88,9 +90,24 @@ with gr.Blocks() as demo:
         personalidade = gr.Dropdown(label="Personalidade", choices=PERSONALIDADES, value=PERSONALIDADE_PADRAO)
         botao = gr.Button("Perguntar")
     resposta = gr.Textbox(label="Resposta da IA", lines=6)
-    trechos_usados = gr.Textbox(label="Trechos do material usados", lines=6)
+    mostrar_trechos = gr.Radio([
+        "Mostrar",
+        "Ocultar",
+    ], value="Ocultar", label="Trechos")
+    trechos_usados = gr.Textbox(
+        label="Trechos do material usados", lines=6, visible=False
+    )
+    mostrar_trechos.change(
+        lambda opcao: gr.update(visible=opcao == "Mostrar"),
+        inputs=mostrar_trechos,
+        outputs=trechos_usados,
+    )
     status = gr.Textbox(label="Status", value="", interactive=False)
-    botao.click(fn=interagir, inputs=[pergunta, personalidade], outputs=[resposta, trechos_usados])
+    botao.click(
+        fn=interagir,
+        inputs=[pergunta, personalidade, mostrar_trechos],
+        outputs=[resposta, trechos_usados],
+    )
     gr.Button("Salvar histórico").click(fn=salvar_historico, outputs=status)
     gr.Button("Resetar base").click(fn=resetar_dados, outputs=status)
 


### PR DESCRIPTION
## Summary
- keep trechos textbox visibility synced with the "Trechos" radio option
- clarify toggle behavior in README

## Testing
- `python -m py_compile chat_aluno.py gerar_resposta.py processar_aulas.py base_consulta.py`

------
https://chatgpt.com/codex/tasks/task_e_684374f1e8c88327bc0936d23e733bc1