### PR TITLE
Implement chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Há um menu suspenso **Personalidade** para escolher qual arquivo de template us
 
 Também é possível pressionar **Enter** no campo de pergunta para enviar a mensagem sem clicar no botão.
 
-Também há um botão "Resetar base" para apagar os arquivos processados e recomeçar do zero.
+Há também botões para **Salvar histórico**, **Carregar histórico** e **Limpar histórico**.
+O chat mantém no contexto apenas as 10 últimas mensagens trocadas com a IA.
+Existe ainda um botão "Resetar base" para apagar os arquivos processados e recomeçar do zero.
 
 Por padrão, os trechos do material usados na resposta ficam ocultos. O
 controle **Trechos** permite exibi‑los ou escondê‑los a qualquer momento, e a


### PR DESCRIPTION
## Summary
- support interactive chat history with only the last 10 messages
- add save/load/clear history helpers for chat
- automatically load saved history on startup
- document the new history features in README

## Testing
- `python -m py_compile gerar_resposta.py chat_aluno.py base_consulta.py processar_aulas.py`

------
https://chatgpt.com/codex/tasks/task_e_6843887b8f248327851238ae8a2887fe